### PR TITLE
Use Github Actions To Compile Automatically

### DIFF
--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -1,0 +1,109 @@
+﻿name: Build On Push
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build_main:
+    name: Build for ${{ matrix.target_branch }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_branch:
+          - sm-latest
+          - sm-1.11
+        include:
+          - dbg_ext: pdb
+
+          - target_branch: sm-latest
+            mm_branch: "master"
+            sm_branch: "master"
+
+          - os: sm-1.11
+            mm_branch: "1.11-dev"
+            sm_branch: "1.11-dev"
+
+    steps:
+    - name: Add msbuild to PATH (Windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v1.1.3
+
+    - name: Install (Windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        :: See https://github.com/microsoft/vswhere/wiki/Find-VC
+        for /f "usebackq delims=*" %%i in (`vswhere -latest -property installationPath`) do (
+          call "%%i"\Common7\Tools\vsdevcmd.bat -arch=x86 -host_arch=x64
+        )
+        
+        :: Loop over all environment variables and make them global.
+        for /f "delims== tokens=1,2" %%a in ('set') do (
+          echo>>"%GITHUB_ENV%" %%a=%%b
+        )
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Setup ambuild
+      run: |
+        python -m pip install wheel
+        pip install git+https://github.com/alliedmodders/ambuild
+    - name: Fetch Metamod:Source ${{ matrix.mm_branch }}
+      uses: actions/checkout@v3
+      with:
+        repository: alliedmodders/metamod-source
+        ref: ${{ matrix.mm_branch }}
+        path: mmsource
+
+    - name: Fetch SourceMod ${{ matrix.sm_branch }}
+      uses: actions/checkout@v3
+      with:
+        repository: alliedmodders/sourcemod
+        ref: ${{ matrix.sm_branch }}
+        path: sourcemod
+        submodules: recursive
+
+    - name: Fetch Source SDKs
+      shell: bash
+      run: |
+        git clone --mirror https://github.com/alliedmodders/hl2sdk hl2sdk-proxy-repo
+        sdks=(tf2)
+        for sdk in "${sdks[@]}"
+        do
+          git clone hl2sdk-proxy-repo -b $sdk hl2sdk-$sdk
+        done
+
+    - name: Fetch PathFollower
+      uses: actions/checkout@v3
+      with:
+        path: pathfollower
+
+    - name: Build Files
+      working-directory: pathfollower
+      run: |
+        mkdir post
+        cd post
+        python3 ../configure.py --enable-optimize --sdks=present --sm-path="${{ github.workspace }}/sourcemod" --mms_path="${{ github.workspace }}/mmsource"
+        ambuild
+
+    - name: Get Short SHA
+      uses: benjlevesque/short-sha@v2.1
+      id: short-sha
+
+    - name: Upload Artifact for ${{ matrix.target_branch }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: pathfollower-${{ runner.target_branch }}-${{ steps.short-sha.outputs.sha }}
+        path: |
+            pathfollower/post/package/*
+
+    - name: Upload Debug Symbols for ${{ matrix.target_branch }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: pathfollower-dbgsym-${{ runner.target_branch }}-${{ steps.short-sha.outputs.sha }}
+        path: |
+            pathfollower/post/**/*.${{ matrix.dbg_ext }}

--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -21,9 +21,12 @@ jobs:
             mm_branch: "master"
             sm_branch: "master"
 
-          - os: sm-1.11
+          - target_branch: sm-1.11
             mm_branch: "1.11-dev"
             sm_branch: "1.11-dev"
+    env:
+      DEPENDENCIES_FOLDER: dependencies
+      DEPENDENCIES_ROOT: ${{ github.workspace }}/dependencies
 
     steps:
     - name: Add msbuild to PATH (Windows)
@@ -67,11 +70,14 @@ jobs:
         path: sourcemod
         submodules: recursive
 
-    - name: Fetch Source SDKs
+    - name: Fetch Dependencies
       shell: bash
       run: |
+        mkdir -p ${{ env.DEPENDENCIES_FOLDER }}
+        cd ${{ env.DEPENDENCIES_FOLDER }}
+
         git clone --mirror https://github.com/alliedmodders/hl2sdk hl2sdk-proxy-repo
-        sdks=(tf2)
+        sdks=(tf2 sdk2013)
         for sdk in "${sdks[@]}"
         do
           git clone hl2sdk-proxy-repo -b $sdk hl2sdk-$sdk
@@ -87,7 +93,7 @@ jobs:
       run: |
         mkdir post
         cd post
-        python3 ../configure.py --enable-optimize --sdks=present --sm-path="${{ github.workspace }}/sourcemod" --mms_path="${{ github.workspace }}/mmsource"
+        python3 ../configure.py --enable-optimize --sdks=tf2 --hl2sdk-root="${{ env.DEPENDENCIES_ROOT }}" --sm-path="${{ github.workspace }}/sourcemod" --mms-path="${{ github.workspace }}/mmsource"
         ambuild
 
     - name: Get Short SHA
@@ -97,13 +103,13 @@ jobs:
     - name: Upload Artifact for ${{ matrix.target_branch }}
       uses: actions/upload-artifact@v3
       with:
-        name: pathfollower-${{ runner.target_branch }}-${{ steps.short-sha.outputs.sha }}
+        name: pathfollower-${{ matrix.target_branch }}-${{ steps.short-sha.outputs.sha }}
         path: |
             pathfollower/post/package/*
 
     - name: Upload Debug Symbols for ${{ matrix.target_branch }}
       uses: actions/upload-artifact@v3
       with:
-        name: pathfollower-dbgsym-${{ runner.target_branch }}-${{ steps.short-sha.outputs.sha }}
+        name: pathfollower-dbgsym-${{ matrix.target_branch }}-${{ steps.short-sha.outputs.sha }}
         path: |
             pathfollower/post/**/*.${{ matrix.dbg_ext }}


### PR DESCRIPTION
Adds a github action workflow that will automatically build this extension when a push is made to the master branch.
It will compile against sourcemod 1.11 and 1.12, creating separate packages for both.
Output is upload as artifacts and includes compiled extension binary and debug symbols for debugging crashes.

Also this is evil: `'tf2':  SDK('HL2SDKTF2', '2.tf2', '11', 'TF2', WinLinuxMac, 'sdk2013'), # MODIFIED: use sdk2013 instead of tf2`